### PR TITLE
remove-hardcoded-ids

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const { getExchangeRate, getTransactions, createTransaction, getAllAccounts, updateOriginalTransaction, searchTransactionsByMemo, deleteTransaction, updateServerKnowledge, getServerKnowledge } = require('./helpers/api');
 const calculateDifferenceTransaction = require('./helpers/transactions');
+require('dotenv').config();
 
 // eslint-disable-next-line no-unused-vars
 exports.handler = async(event, context) => {
@@ -74,7 +75,12 @@ const processBudget = async(budgetId, flag, baseCurrency, exchangeAcct) => {
 
 const main = async() => {
   const budgets = [
-    { id: '23694cd3-2247-4d5c-ae94-2a805edc5737', baseCurrency: 'USD', flag: '🇨🇦', exchangeAcct: 'fad104ac-368e-412b-8934-b20562330608'}
+    {
+      id: process.env.BUDGET_ID,
+      baseCurrency: 'USD',
+      flag: '🇨🇦',
+      exchangeAcct: process.env.EXCHANGE_ACCOUNT_ID
+    }
   ];
 
   for (const budget of budgets) {

--- a/app.js
+++ b/app.js
@@ -5,71 +5,81 @@ require('dotenv').config();
 // eslint-disable-next-line no-unused-vars
 exports.handler = async(event, context) => {
   try {
+    console.log('Starting YNAB currency conversion...');
     await main();
+    console.log('✨ Processing completed successfully');
     return { statusCode: 200, body: JSON.stringify('Budget processing completed.') };
   } catch (error) {
-    console.error(error);
+    console.error('❌ Processing failed:', error);
     return { statusCode: 500, body: JSON.stringify('An error occurred while processing budgets.') };
   }
 };
 
 const processBudget = async(budgetId, flag, baseCurrency, exchangeAcct) => {
-  let lastServerKnowledge = await getServerKnowledge(budgetId);
-  const accounts = await getAllAccounts(budgetId);
-
-  let latestServerKnowledge;
-
-  const secondaryAccount = accounts.find(account => account.name.includes('💱'));
-  if (!secondaryAccount) {
-    console.error('Secondary account with symbol 💱 not found.');
-    return;
-  }
-  const secondaryAccountId = secondaryAccount.id;
-  console.log(`Secondary account ID for budget ${budgetId}: ${secondaryAccountId}`);
-
-  const validAccounts = accounts.filter(account =>
-    account.name.includes(flag) && !account.closed
-  ).map(account => ({ ...account, currency: baseCurrency === 'CAD' ? 'USD' : 'CAD' }));
-
-  for (const account of validAccounts) {
-    const currencyRate = await getExchangeRate(account.currency);
-    console.log(`Exchange rate for ${account.currency}: ${currencyRate}`);
-
-    const { transactions, newServerKnowledge } = await getTransactions(budgetId, account.id, lastServerKnowledge);
-    console.log(`Found ${transactions.length} transactions for account ${account.name} in budget ${budgetId}`);
-
-    for (const transaction of transactions) {
-      if (transaction.deleted) {
-        // Deleting related transactions
-        const relatedTransactions = await searchTransactionsByMemo(budgetId, secondaryAccountId, transaction.id);
-        for (const relatedTransaction of relatedTransactions) {
-          const deleteResponse = await deleteTransaction(budgetId, relatedTransaction.id);
-          latestServerKnowledge = deleteResponse.newServerKnowledge;
-          console.log(`Transaction was deleted, removing: ${relatedTransaction.id}`);
-        }
-      } else if (transaction.flag_color === 'green') {
-        // Handling updated transactions
-        const relatedTransactions = await searchTransactionsByMemo(budgetId, secondaryAccountId, transaction.id);
-        for (const relatedTransaction of relatedTransactions) {
-          await deleteTransaction(budgetId, relatedTransaction.id);
-          console.log(`Transaction has been updated, removing old transaction: ${relatedTransaction.id}`);
+  console.log('Processing budget:', { budgetId, flag, baseCurrency });
+  
+  try {
+    let lastServerKnowledge = await getServerKnowledge(budgetId);
+    console.log('Retrieved server knowledge:', lastServerKnowledge);
     
-          const newDifferenceTransaction = calculateDifferenceTransaction(transaction, currencyRate, account.name, secondaryAccountId);
-          await createTransaction(budgetId, newDifferenceTransaction, exchangeAcct);
-          console.log(`New difference transaction created for updated transaction ID: ${transaction.id}`);
-        }
-        const updateOriginalResponse = await updateOriginalTransaction(budgetId, transaction.id);
-        latestServerKnowledge = updateOriginalResponse.newServerKnowledge;
-        console.log('Original transaction updated successfully!');
-      } else {
-        const differenceTransaction = calculateDifferenceTransaction(transaction, currencyRate, account.name, secondaryAccountId);
-        await createTransaction(budgetId, differenceTransaction, exchangeAcct);
-        console.log(`New transaction created for ID: ${transaction.id} in budget ${budgetId}`);
-        const updateOriginalResponse = await updateOriginalTransaction(budgetId, transaction.id);
-        latestServerKnowledge = updateOriginalResponse.newServerKnowledge;
-      }
-      await updateServerKnowledge(budgetId, latestServerKnowledge || newServerKnowledge);
+    const accounts = await getAllAccounts(budgetId);
+    console.log('Retrieved accounts:', accounts.length);
+
+    let latestServerKnowledge;
+
+    const secondaryAccount = accounts.find(account => account.name.includes('💱'));
+    if (!secondaryAccount) {
+      throw new Error('Secondary account with symbol 💱 not found');
     }
+    const secondaryAccountId = secondaryAccount.id;
+    console.log('Found secondary account:', secondaryAccountId);
+
+    const validAccounts = accounts.filter(account =>
+      account.name.includes(flag) && !account.closed
+    ).map(account => ({ ...account, currency: baseCurrency === 'CAD' ? 'USD' : 'CAD' }));
+
+    for (const account of validAccounts) {
+      const currencyRate = await getExchangeRate(account.currency);
+      console.log(`Exchange rate for ${account.currency}: ${currencyRate}`);
+
+      const { transactions, newServerKnowledge } = await getTransactions(budgetId, account.id, lastServerKnowledge);
+      console.log(`Found ${transactions.length} transactions for account ${account.name} in budget ${budgetId}`);
+
+      for (const transaction of transactions) {
+        if (transaction.deleted) {
+          // Deleting related transactions
+          const relatedTransactions = await searchTransactionsByMemo(budgetId, secondaryAccountId, transaction.id);
+          for (const relatedTransaction of relatedTransactions) {
+            const deleteResponse = await deleteTransaction(budgetId, relatedTransaction.id);
+            latestServerKnowledge = deleteResponse.newServerKnowledge;
+            console.log(`Transaction was deleted, removing: ${relatedTransaction.id}`);
+          }
+        } else if (transaction.flag_color === 'green') {
+          // Handling updated transactions
+          const relatedTransactions = await searchTransactionsByMemo(budgetId, secondaryAccountId, transaction.id);
+          for (const relatedTransaction of relatedTransactions) {
+            await deleteTransaction(budgetId, relatedTransaction.id);
+            console.log(`Transaction has been updated, removing old transaction: ${relatedTransaction.id}`);
+    
+            const newDifferenceTransaction = calculateDifferenceTransaction(transaction, currencyRate, account.name, secondaryAccountId);
+            await createTransaction(budgetId, newDifferenceTransaction, exchangeAcct);
+            console.log(`New difference transaction created for updated transaction ID: ${transaction.id}`);
+          }
+          const updateOriginalResponse = await updateOriginalTransaction(budgetId, transaction.id);
+          latestServerKnowledge = updateOriginalResponse.newServerKnowledge;
+          console.log('Original transaction updated successfully!');
+        } else {
+          const differenceTransaction = calculateDifferenceTransaction(transaction, currencyRate, account.name, secondaryAccountId);
+          await createTransaction(budgetId, differenceTransaction, exchangeAcct);
+          console.log(`New transaction created for ID: ${transaction.id} in budget ${budgetId}`);
+          const updateOriginalResponse = await updateOriginalTransaction(budgetId, transaction.id);
+          latestServerKnowledge = updateOriginalResponse.newServerKnowledge;
+        }
+        await updateServerKnowledge(budgetId, latestServerKnowledge || newServerKnowledge);
+      }
+    }
+  } catch (error) {
+    console.error('❌ ERROR:', { message: 'Error processing budget', error });
   }
 };
 
@@ -87,3 +97,13 @@ const main = async() => {
     await processBudget(budget.id, budget.flag, budget.baseCurrency, budget.exchangeAcct);
   }
 };
+
+// If running directly (not as Lambda)
+if (require.main === module) {
+  main()
+    .then(() => console.log('✨ Completed'))
+    .catch(error => {
+      console.error('❌ Failed:', error);
+      process.exit(1);
+    });
+}

--- a/helpers/api.js
+++ b/helpers/api.js
@@ -44,12 +44,20 @@ const getServerKnowledge = async(budgetId) => {
       .eq('id', budgetId)
       .single();
 
-    if (error) throw error;
+    if (error) {
+      console.error('❌ CRITICAL ERROR:', { message: 'Failed to retrieve server knowledge from Supabase', budgetId, error });
+      throw new Error(`Failed to retrieve server knowledge from database: ${error.message}`);
+    }
 
-    return data ? data.server_knowledge : 0;
+    if (!data) {
+      console.error('❌ CRITICAL ERROR:', { message: 'No server knowledge record found', budgetId });
+      throw new Error(`No server knowledge found for budget: ${budgetId}`);
+    }
+
+    return data.server_knowledge;
   } catch (error) {
-    console.error('Error retrieving server knowledge:', error.message);
-    return 0;
+    console.error('❌ CRITICAL ERROR:', { message: 'Server knowledge retrieval failed', budgetId, error });
+    throw error; // Re-throw the error to stop the process
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "newynab",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Changes
- Replaced hardcoded budget and account IDs with environment variables:
  - `BUDGET_ID` for the budget identifier
  - `EXCHANGE_ACCOUNT_ID` for the exchange account identifier
- Enhanced error handling in `getServerKnowledge` to prevent silent failures
  - Now throws errors instead of returning 0, preventing unwanted full resyncs
  - Added structured error logging for better visibility in CloudWatch
- Added local execution support with proper error handling
  - Added `if (require.main === module)` block for local runs
  - Improved console output for local development